### PR TITLE
Add 8 hour option to the timeout command.

### DIFF
--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -33,6 +33,10 @@ const options = [
     value: '3600000',
   },
   {
+    name: '8 ч.',
+    value: '28800000',
+  },
+  {
     name: '24 ч.',
     value: '86400000',
   },


### PR DESCRIPTION
Added an 8-hour option to the timeout command to support working regulars. This allows users to focus during work hours and rejoin chat after the 8-hour period.